### PR TITLE
Update ATM config for new cloud masks

### DIFF
--- a/RVE/RVE_ATM.cfg
+++ b/RVE/RVE_ATM.cfg
@@ -4,7 +4,7 @@ ACTIVE_TEXTURE_MANAGER_CONFIG
     enabled  = true
     OVERRIDES
     {
-		RVE/EVE/Atmosphere/Textures/EarthA.*
+		RVE/EVE/Atmosphere/Textures/Cirrus.*
 		{
             compress = true
             mipmaps = true
@@ -12,7 +12,7 @@ ACTIVE_TEXTURE_MANAGER_CONFIG
             max_size = 0
             make_not_readable = false
         }
-		RVE/EVE/Atmosphere/Textures/EarthCi.*
+		RVE/EVE/Atmosphere/Textures/Low.*
 		{
             compress = true
             mipmaps = true


### PR DESCRIPTION
@Pingopete when you add/remove/change the name of a cloud mask (which needs to be kept readable), you need to update the ATM config to make the new ones kept-readable.
