### PR TITLE
Update clouds.cfg

### DIFF
--- a/RVE/EVE/Atmosphere/clouds.cfg
+++ b/RVE/EVE/Atmosphere/clouds.cfg
@@ -45,7 +45,7 @@ EVE_ATMOSPHERE
 				macroCloudMaterial
 				{
 					_MainTex = RVE/EVE/Atmosphere/Textures/Low
-					_DetailTex = RVE/EVE/Atmosphere/Textures/DetailLow
+					_DetailTex = RVE/EVE/Atmosphere/Textures/detailLow
 					_DetailScale = 14
 					_Color = 1,1,1,1.05
 					_FalloffPow = 0.8


### PR DESCRIPTION
Letter case error causes lower level cloud detail to fail, at least in my Mint Linux KSP build.

As edited, this reference now matches the file exactly.