### PR TITLE
Drastically reduce cloud pin stripping

### DIFF
--- a/RVE/EVE/Atmosphere/clouds.cfg
+++ b/RVE/EVE/Atmosphere/clouds.cfg
@@ -33,7 +33,7 @@ EVE_ATMOSPHERE
 		}
 		Kerbin-cloudsLow
 		{
-			altitude = 2700
+			altitude = 4200
 			speed = 50
 			scaledOverlay = Geometry
 			layer2D


### PR DESCRIPTION
Not an ideal solution, but a possible good interim one.

The low cloud pin stripping appears to be roughly linearly tied to the height of the low cloud layer (lower the cloud layer, issue is much worse. Raise the clouds, issue drastically reduced)

By increasing the height of the lower cloud layer to 4.2 km the visual impact is greatly reduced.
